### PR TITLE
Clear untracked content in third_party/dawn before sync

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,6 +78,7 @@ jobs:
           echo "SOURCE_REF_RESOLVED=$SOURCE_REF_RESOLVED" >> "$GITHUB_ENV"
           cd "$SRC_DIR/.."
           git -C src clean -fd
+          git -C src/third_party/dawn clean -fd || true
           rm -rf -- "$OUT_DIR"
           git -C src am --abort || true
           git -C src/electron fetch upstream --tags


### PR DESCRIPTION
It appears some version of chromium left some untracked files and directories inside third_party/dawn during previous build, causing the next sync to fail:
https://github.com/riscv-forks/electron-riscv-releases/actions/runs/25899891828/job/76120837851

Fix it by try to clear them before sync.

HEAD detached at a94afcc3f32
Untracked files:
  (use "git add <file>..." to include in what will be committed)
        third_party/webgpu-headers/.gitattributes
        third_party/webgpu-headers/.github/
        third_party/webgpu-headers/.gitignore
        third_party/webgpu-headers/LICENSE
        third_party/webgpu-headers/Makefile
        third_party/webgpu-headers/README.md
        third_party/webgpu-headers/gen/
        third_party/webgpu-headers/go.mod
        third_party/webgpu-headers/go.sum
        third_party/webgpu-headers/schema.json
        third_party/webgpu-headers/tests/
        third_party/webgpu-headers/webgpu.h
        third_party/webgpu-headers/webgpu.yml

nothing added to commit but untracked files present (use "git add" to track)